### PR TITLE
Closes CiviCooP/org.civicoop.civirules#86 - don't delete email API ac…

### DIFF
--- a/emailapi.php
+++ b/emailapi.php
@@ -112,7 +112,7 @@ function _emailapi_is_civirules_installed() {
   try {
     $extensions = civicrm_api3('Extension', 'get');
     foreach($extensions['values'] as $ext) {
-      if ($ext['key'] == 'org.civicoop.civirules' &&$ext['status'] == 'installed') {
+      if ($ext['key'] == 'org.civicoop.civirules' && ($ext['status'] == 'installed' || $ext['status'] == 'disabled')) {
         $installed = true;
       }
     }


### PR DESCRIPTION
…tions when disabling CiviRules

Per CiviCooP/org.civicoop.civirules#86, when CiviRules is disabled (but not uninstalled), all `civirule_rule_action` records tied to the `civirule_action` of `emailapi_send` are deleted.  This is expected behavior when uninstalling CiviRules, but not on disabling it.

This modifies `_emailapi_is_civirules_installed()` to consider CiviRules to be installed when it's installed but disabled.  I've tested this successfully.  Since you can't have an extension that was disabled but never installed, this should be a safe modification.