### PR TITLE
Fix issue where civirules extension wasn't being found as API limited…

### DIFF
--- a/emailapi.php
+++ b/emailapi.php
@@ -108,17 +108,18 @@ function emailapi_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
 }
 
 function _emailapi_is_civirules_installed() {
-  $installed = false;
+  $installed = FALSE;
   try {
-    $extensions = civicrm_api3('Extension', 'get');
+    $extensions = civicrm_api3('Extension', 'get', array('options' => array('limit' => 0)));
     foreach($extensions['values'] as $ext) {
       if ($ext['key'] == 'org.civicoop.civirules' && ($ext['status'] == 'installed' || $ext['status'] == 'disabled')) {
-        $installed = true;
+        $installed = TRUE;
       }
     }
     return $installed;
-  } catch (Exception $e) {
-    return false;
   }
-  return false;
+  catch (Exception $e) {
+    return FALSE;
+  }
+  return FALSE;
 }


### PR DESCRIPTION
… to 25

We had an issue getting this install to work correctly on our site as we have > 25 extensions. So the get API call which defaults to a limit of 25 was missing the fact that CiviRules was there and installed as it was after the 25th extension

ping @jaapjansma @johntwyman @ineffyble