### PR TITLE
Remove Extraneous </div> tag

### DIFF
--- a/templates/CRM/Emailapi/Form/CivirulesAction/SendToRelatedContact.tpl
+++ b/templates/CRM/Emailapi/Form/CivirulesAction/SendToRelatedContact.tpl
@@ -48,7 +48,6 @@
     <div class="content" id="location_note">{ts}Note: primary e-mailaddress will be used if location type e-mailaddress not found{/ts}</div>
     <div class="clear"></div>
   </div>
-  </div>
   <div class="crm-section cc">
     <div class="label">{$form.cc.label}</div>
     <div class="content">{$form.cc.html}</div>


### PR DESCRIPTION
There's an extra closing ```</div>``` tag on line 51.  This is bringing the WordPress Footer area up to the middle of the page, covering the Location Type text and moving the clickable area of the dropdown to the left and under the label text.