### PR TITLE
Fix for some bad behavior in issue #10

### DIFF
--- a/api/v3/Email/Send.php
+++ b/api/v3/Email/Send.php
@@ -113,7 +113,7 @@ function civicrm_api3_email_send($params) {
     //CRM-5734
 
     // get tokens to be replaced
-    $tokens = array_merge(CRM_Utils_Token::getTokens($body_text),
+    $tokens = array_merge_recursive(CRM_Utils_Token::getTokens($body_text),
         CRM_Utils_Token::getTokens($body_html),
         CRM_Utils_Token::getTokens($body_subject));
 


### PR DESCRIPTION
We're seeing behavior described in #10 , and this change fixes the issue for us.

Actually what's happening for us is that by using `array_merge()` here, tokens that are not in `$body_subject` are simply not appearing in `$tokens`. Issue #10 doesn't describe the issue in exactly that way, but there's some chance that indeed that's the situation.